### PR TITLE
Fix character encoding issues caused by non-breaking space in breakpoints.js

### DIFF
--- a/breakpoints.js
+++ b/breakpoints.js
@@ -43,7 +43,7 @@
 			if(typeof callbacks != 'object') callbacks = [callbacks];
 
 			// return if no width or no callbacks are defined
-			if(!width || !callbacks.length) return;
+			if(!width || !callbacks.length) return;
 
 			var bpWidth = width.toString();
 


### PR DESCRIPTION
Replace non-breaking space (U+00A0) with regular space (U+0020) to avoid encoding issues